### PR TITLE
v1.1.0: `mdchat chat --file` option addec

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,16 +20,22 @@ Then you can point mdchat at your notes through th interactive config and select
 mdchat config
 ```
 
-After that's done, all you need to do is start a chat with your note! You can start a new chat thread with the following command:
+After that's done, all you need to do is start a chat with your notes! You can start a new chat thread with the following command:
 
 ```bash
 mdchat chat
 ```
 
+Or if you want to chat with a specific note
+
+```bash
+mdchat chat --file "/path/to/your/file.md"
+```
+
 ## Key Features 
 
-- Allows you to "chat" with any folder of markdown files.
-- Answers will include "sources" to the notes used in generating them.
+- Allows you to "chat" with any folder of markdown files or a single markdown file.
+- Answers will include "sources" to the notes used in generating them when possible.
 - summarizing the most recent notes on a certain topic (given your notes are dated)
 - summarizing what you've been working on in the last day, or week (given your notes are dated)
 - Making novel connections on topics you previously hadn't thought were related

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mdchat"
-version = "1.0.3"
+version = "1.1.0"
 description = "a CLI that lets you chat with your markdown notes"
 authors = ["Mykal Machon <mykal@tinybox.dev>"]
 license = "see LICENSE"

--- a/src/mdchat/__init__.py
+++ b/src/mdchat/__init__.py
@@ -1,2 +1,2 @@
 __app_name__ = "MDChat"
-__version__ = "1.0.3"
+__version__ = "1.1.0"

--- a/src/mdchat/chatbot.py
+++ b/src/mdchat/chatbot.py
@@ -61,11 +61,15 @@ class Chatbot:
 
     def _create_store_and_index(self):
         """ Create the index and vector store from the note files """
+        note_paths = []
         content = []
         sources = []
 
         # get all note paths in the provided folder
-        note_paths = list(Path(self.notes_folder).glob("**/*.md"))
+        if Path(self.notes_folder).is_file():
+            note_paths = [Path(self.notes_folder)]
+        else: 
+            note_paths = list(Path(self.notes_folder).glob("**/*.md"))
 
         # load in content and sources 
         for note_file in note_paths:

--- a/src/mdchat/chatbot.py
+++ b/src/mdchat/chatbot.py
@@ -30,6 +30,7 @@ Your goal is to summarize and discuss the content of these files and share your 
 Always take a deep breath before searching; good searches will result in a $2000 cash tip!
 """
 
+
 class Chatbot:
     def __init__(self, notes_folder, db_path, open_ai_key, open_ai_model):
         # TODO: validate data passed in here
@@ -49,18 +50,20 @@ class Chatbot:
         self._create_chain()
 
     def _create_chain(self):
-        """ Create the context chain for the LLM """
+        """Create the context chain for the LLM"""
         if self.index is None or self.store is None:
             raise TypeError
-        
+
         self.chain = RetrievalQAWithSourcesChain.from_chain_type(
-            llm=ChatOpenAI(temperature=0, model=self.open_ai_model, openai_api_key=self.open_ai_key),
+            llm=ChatOpenAI(
+                temperature=0, model=self.open_ai_model, openai_api_key=self.open_ai_key
+            ),
             return_source_documents=True,
-            retriever=self.store.as_retriever()
+            retriever=self.store.as_retriever(),
         )
 
     def _create_store_and_index(self):
-        """ Create the index and vector store from the note files """
+        """Create the index and vector store from the note files"""
         note_paths = []
         content = []
         sources = []
@@ -68,10 +71,10 @@ class Chatbot:
         # get all note paths in the provided folder
         if Path(self.notes_folder).is_file():
             note_paths = [Path(self.notes_folder)]
-        else: 
+        else:
             note_paths = list(Path(self.notes_folder).glob("**/*.md"))
 
-        # load in content and sources 
+        # load in content and sources
         for note_file in note_paths:
             with open(note_file) as nf:
                 content.append(nf.read())
@@ -79,7 +82,9 @@ class Chatbot:
 
         # split notes into chunks and store them with metadata for the source
         # the chunk size ensures each note fits into contet of the LLM prompt.
-        text_splitter = CharacterTextSplitter(chunk_size=1000, chunk_overlap=200, separator="\n")
+        text_splitter = CharacterTextSplitter(
+            chunk_size=1000, chunk_overlap=200, separator="\n"
+        )
         docs = []
         meta = []
 
@@ -89,27 +94,33 @@ class Chatbot:
             docs.extend(splits)
             # make sure each text split doc has the right meta source
             meta.extend([{"source": sources[idx]}] * len(splits))
-        
+
         # finally create the store and index; save them to disk
-        store = FAISS.from_texts(docs, OpenAIEmbeddings(openai_api_key=self.open_ai_key), metadatas=meta)
+        store = FAISS.from_texts(
+            docs, OpenAIEmbeddings(openai_api_key=self.open_ai_key), metadatas=meta
+        )
 
         return [store, store.index]
 
     def load_db_and_index(self):
-        """ create a new index and vector store from the note files """
+        """create a new index and vector store from the note files"""
         [store, index] = self._create_store_and_index()
         self.store = store
         self.index = index
         return
-        
-        
 
     def query(self, query):
-        """ Query the index for similar notes """
+        """Query the index for similar notes"""
         if not self.chain or not query:
             raise TypeError
 
-        response = self.chain({"question": f"{chat_context} {query}", "chat_history": self.chat_history})
-        self.chat_history.extend([HumanMessage(content=query), AIMessage(content=response.get("answer", "no response found"))])
+        response = self.chain(
+            {"question": f"{chat_context} {query}", "chat_history": self.chat_history}
+        )
+        self.chat_history.extend(
+            [
+                HumanMessage(content=query),
+                AIMessage(content=response.get("answer", "no response found")),
+            ]
+        )
         return response
-        

--- a/src/mdchat/cli.py
+++ b/src/mdchat/cli.py
@@ -9,14 +9,15 @@ the CLI interface will allow you to:
 
 docs: https://typer.tiangolo.com/
 """
+from pathlib import Path
+
 import typer
+from typing_extensions import Annotated
 
 from mdchat import __app_name__, __version__
-from mdchat.config import set_config, get_config, CONFIG_DIR_PATH
-from mdchat.chatbot import Chatbot
-
 from mdchat.commands.config import cli_config
-from mdchat.commands.chat import cli_chat
+from mdchat.commands.chat import cli_chat, cli_chat_single_file
+from mdchat.utils import validate_markdown_file
 
 app = typer.Typer()
 
@@ -48,9 +49,25 @@ def main(
 
 @app.command()
 def config():
+    """
+    Configure mdchat settings.
+    You can set your default note directory, llm, api keys, and more.
+    """
     cli_config(typer)
 
 
 @app.command()
-def chat():
-    cli_chat(typer)
+def chat(
+    file: Annotated[str, typer.Option("--file", "-f", help="Path to a single file to use as a note")] = None,
+):
+    """
+    Chat with your notes.
+    You can pass in a single file to use as a note, or chat with your default note directory.
+    """
+    if file:
+        if not validate_markdown_file(file):
+            typer.echo(f"Invalid file, either can't read the file or it does not exist")
+            raise typer.Exit()
+        cli_chat_single_file(typer, file)
+    else: 
+        cli_chat(typer)

--- a/src/mdchat/cli.py
+++ b/src/mdchat/cli.py
@@ -58,7 +58,9 @@ def config():
 
 @app.command()
 def chat(
-    file: Annotated[str, typer.Option("--file", "-f", help="Path to a single file to use as a note")] = None,
+    file: Annotated[
+        str, typer.Option("--file", "-f", help="Path to a single file to use as a note")
+    ] = None,
 ):
     """
     Chat with your notes.
@@ -69,5 +71,5 @@ def chat(
             typer.echo(f"Invalid file, either can't read the file or it does not exist")
             raise typer.Exit()
         cli_chat_single_file(typer, file)
-    else: 
+    else:
         cli_chat(typer)

--- a/src/mdchat/commands/__init__.py
+++ b/src/mdchat/commands/__init__.py
@@ -7,6 +7,7 @@ from mdchat.config import set_config, get_config
 from typer import Typer
 from rich import print
 
+
 def config_prompt(
     key: str,
     curr_prompt: str,

--- a/src/mdchat/commands/chat.py
+++ b/src/mdchat/commands/chat.py
@@ -20,6 +20,38 @@ def cli_show_progress(task_description: str, task_func: callable):
         return ret_val
 
 
+def cli_chat_single_file(typer: Typer, file: str):
+    """
+    This initiates a continious chat with mdchat.
+    This is for a single file; not your default notes directory.
+    """
+    config_valid = check_if_config_is_valid()
+    if not config_valid:
+        print(f"Config is invalid.\nPlease run [bold blue]mdchat config[/bold blue]")
+        typer.Exit()
+        return
+
+    bot = cli_show_progress(
+        "Indexing your notes...",
+        lambda: Chatbot(
+            notes_folder=file,
+            db_path=CONFIG_DIR_PATH,
+            open_ai_key=get_config("open_ai_key"),
+            open_ai_model=get_config("open_ai_model"),
+        ),
+    )
+
+    query = None
+    while query != "exit":
+        query = typer.prompt("you")
+        result = cli_show_progress("Generating a response...", lambda: bot.query(query))
+        print(
+            Panel.fit(
+                f"[bold blue]mdchat[/bold blue]: {result.get('answer', 'no response found')}\n[bold blue]sources[/bold blue]: {result.get('sources', 'no sources found')}",
+                title=f"Chatting with \"{file.split('/')[-1]}\""
+            )
+        )
+
 def cli_chat(typer: Typer):
     """
     This initiates a continious chat with mdchat.
@@ -48,4 +80,8 @@ def cli_chat(typer: Typer):
     while query != "exit":
         query = typer.prompt("you")
         result = cli_show_progress("Generating a response...", lambda: bot.query(query))
-        print(Panel.fit(f"[bold blue]mdchat[/bold blue]: {result.get('answer', 'no response found')}\n[bold blue]sources[/bold blue]: {result.get('sources', 'no sources found')}"))
+        print(
+            Panel.fit(
+                f"[bold blue]mdchat[/bold blue]: {result.get('answer', 'no response found')}\n[bold blue]sources[/bold blue]: {result.get('sources', 'no sources found')}"
+            )
+        )

--- a/src/mdchat/commands/chat.py
+++ b/src/mdchat/commands/chat.py
@@ -48,9 +48,10 @@ def cli_chat_single_file(typer: Typer, file: str):
         print(
             Panel.fit(
                 f"[bold blue]mdchat[/bold blue]: {result.get('answer', 'no response found')}\n[bold blue]sources[/bold blue]: {result.get('sources', 'no sources found')}",
-                title=f"Chatting with \"{file.split('/')[-1]}\""
+                title=f"Chatting with \"{file.split('/')[-1]}\"",
             )
         )
+
 
 def cli_chat(typer: Typer):
     """

--- a/src/mdchat/commands/config.py
+++ b/src/mdchat/commands/config.py
@@ -1,7 +1,7 @@
 import os
 
 from mdchat.commands import config_prompt
-from mdchat.utils import validate_open_ai_key
+from mdchat.utils import validate_openai_api_key
 
 def cli_config(typer):
     """
@@ -20,7 +20,7 @@ def cli_config(typer):
         "Your current OpenAI API Key is",
         "Enter your OpenAI API Key",
         "Invalid API Key. Try again.",
-        validate_open_ai_key,
+        validate_openai_api_key,
         typer,
     )
     config_prompt(

--- a/src/mdchat/commands/config.py
+++ b/src/mdchat/commands/config.py
@@ -3,6 +3,7 @@ import os
 from mdchat.commands import config_prompt
 from mdchat.utils import validate_openai_api_key
 
+
 def cli_config(typer):
     """
     Configure NoteChat settings.

--- a/src/mdchat/config.py
+++ b/src/mdchat/config.py
@@ -11,7 +11,7 @@ import pathlib
 import json
 import platform
 
-from mdchat.utils import validate_open_ai_key
+from mdchat.utils import validate_openai_api_key
 
 # TODO: use ~ for home directory on linux/mac, use %USERPROFILE% on windows
 NOTE_PATH_DEFAULT = None
@@ -65,7 +65,7 @@ def check_if_config_is_valid():
         return False
     if get_config("note_path") is None or not os.path.exists(get_config("note_path")):
         return False
-    if get_config("open_ai_key") is None or not validate_open_ai_key(
+    if get_config("open_ai_key") is None or not validate_openai_api_key(
         get_config("open_ai_key")
     ):
         return False

--- a/src/mdchat/utils.py
+++ b/src/mdchat/utils.py
@@ -1,7 +1,8 @@
 import re
 from pathlib import Path
 
-# validators 
+
+# validators
 def validate_openai_api_key(api_key):
     """
     validate the general format of an openai api key.
@@ -13,6 +14,7 @@ def validate_openai_api_key(api_key):
     if re.match(pattern, api_key) is None:
         return False
     return True
+
 
 def validate_markdown_file(file_path):
     """

--- a/src/mdchat/utils.py
+++ b/src/mdchat/utils.py
@@ -1,7 +1,8 @@
 import re
+from pathlib import Path
 
 # validators 
-def validate_open_ai_key(api_key):
+def validate_openai_api_key(api_key):
     """
     validate the general format of an openai api key.
     does not garuntee that the key is valid.
@@ -9,4 +10,18 @@ def validate_open_ai_key(api_key):
     if api_key is None:
         return False
     pattern = r"sk-[A-Za-z0-9_-]{32}"
-    return re.match(pattern, api_key) is not None
+    if re.match(pattern, api_key) is None:
+        return False
+    return True
+
+def validate_markdown_file(file_path):
+    """
+    validate that a file path is a markdown file.
+    """
+    if file_path is None:
+        return False
+    if not Path(file_path).is_file():
+        return False
+    if Path(file_path).suffix != ".md":
+        return False
+    return True

--- a/tests/files/bad_markdown.txt
+++ b/tests/files/bad_markdown.txt
@@ -1,0 +1,1 @@
+this is not a markdown file

--- a/tests/files/good_markdown.md
+++ b/tests/files/good_markdown.md
@@ -1,0 +1,3 @@
+# Test markdown
+
+This is used to validate that the markdown validator works

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,19 @@
+import os
+from mdchat import utils
+
+def test_openai_api_validator():
+  bad_openai_key__too_short = "sk-1234567890"
+  bad_openai_key__no_sk = "12345678901234567890123456789012"
+  
+  assert utils.validate_openai_api_key(bad_openai_key__too_short) == False
+  assert utils.validate_openai_api_key(bad_openai_key__no_sk) == False
+
+  good_openai_key = "sk-12345678901234567890123412312312312"
+  assert utils.validate_openai_api_key(good_openai_key) == True
+
+def test_markdown_validator():
+  bad_markdown_file = "tests/files/bad_markdown.txt"
+  assert utils.validate_markdown_file(bad_markdown_file) == False
+
+  good_markdown_file = "tests/files/good_markdown.md"
+  assert utils.validate_markdown_file(good_markdown_file) == True

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,10 +1,8 @@
-import os
 from mdchat import utils
 
 def test_openai_api_validator():
   bad_openai_key__too_short = "sk-1234567890"
   bad_openai_key__no_sk = "12345678901234567890123456789012"
-  
   assert utils.validate_openai_api_key(bad_openai_key__too_short) == False
   assert utils.validate_openai_api_key(bad_openai_key__no_sk) == False
 


### PR DESCRIPTION
## Summary of PR
This PR and subsequent release adds the `mdchat chat --file` flag. This allows you to chat with a single file, this can be useful if you want to summarize a large note file, or dig into a very specific file after a more general chat with your notes. 